### PR TITLE
ADDED:  node affinity and registry secrets

### DIFF
--- a/src/smc_pyutil/smc_pyutil/smc_compute.py
+++ b/src/smc_pyutil/smc_pyutil/smc_compute.py
@@ -633,6 +633,15 @@ metadata:
     network: "{network}"
     node_selector: "{node_selector}"
 spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: cloud.google.com/gke-nodepool
+            operator: In
+            values:
+            - cocalc-project
   containers:
     - name: "{pod_name}"
       image: "{registry}/cocalc-kubernetes-project"
@@ -664,6 +673,8 @@ spec:
         - name: home
           mountPath: /home/user
   automountServiceAccountToken: false
+  imagePullSecrets:
+      - name: gcrcred
   volumes:
     - name: home
       nfs:


### PR DESCRIPTION
# Description
- Node affinity enables to start project pod on cocalc node 
- Registry secrets to pull project image from private registry

# Testing Steps
1.  Build image and push to registry
2.  Restart cocalc server pod
1.

# Relevant Issues

### [Checklist](https://github.com/sagemathinc/cocalc/wiki/PR-Checklist):
- [ ] Run eslint on new and edited files
- [ ] All new code is actually used.
- [ ] Non-obvious code has some sort of comments.

Front end:
- [ ] Restart at least one project and check its `~/.smc/local_hub/local_hub.log`
- [ ] Completely restart Webpack with `./w` in `/src`
- [ ] Completely restart the hub by killing and restarting `./start_hub.py` in `/src/dev/project`
- [ ] Screenshots if relevant.
